### PR TITLE
Remove kanboard and switch to my todo-rest server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # flask-twitch-todo
-a small flask service that reads from kanboard
+a small flask service that reads from todo-rest
 
 
 # Usage instructions.
-1) Setup kanboard. [Instructions here]('https://docs.kanboard.org/en/latest/admin_guide/docker.html#running-the-container')
+1) Setup todo-rest. [Instructions here]('https://rhodecode.nyx.xyz/todo-rest/')
 2) Clone this repository
 3) setup venv
 ```py

--- a/app.py
+++ b/app.py
@@ -1,18 +1,11 @@
 import os
 from flask import Flask, render_template, url_for, redirect
 from flask_bootstrap import Bootstrap
-import kanboard
-
-
+import httpx
 
 app = Flask(__name__)
-
 app.config.from_pyfile('config.py')
-
-
 bootstrap = Bootstrap(app)
-
-kb = kanboard.Client(app.config['KANBOARD_ENDPOINT'],app.config['KANBOARD_METHOD'], app.config['KANBOARD_API_KEY'])
 
 @app.route('/')
 def index():
@@ -20,9 +13,9 @@ def index():
 
 @app.route('/list')
 def show_list():
-    open_tasks = kb.get_all_tasks(project_id = app.config['KANBOARD_PROJECT_ID'], status_id = 1)
-    closed_tasks = kb.get_all_tasks(project_id = app.config['KANBOARD_PROJECT_ID'], status_id = 0)
-    return render_template('list.html', open_tasks = open_tasks, closed_tasks = closed_tasks) 
+    r = httpx.get('http://localhost:8000')
+    tasks = r.json()
+    return render_template('list.html', open_tasks = tasks)
 
 
 

--- a/requirments.txt
+++ b/requirments.txt
@@ -1,4 +1,4 @@
 flask
-kanboard
+httpx
 bootstrap-flask
 requests


### PR DESCRIPTION
This removes the need for running kanboard, and moves the todo handling to [todo-rest](https://rhodecode.nyx.xyz/todo-rest/), 
a minimal sqlite rest-api for handling todos